### PR TITLE
Corrected tab order for editor (fixes #3).

### DIFF
--- a/base.py
+++ b/base.py
@@ -523,6 +523,14 @@ def main():
 	entryBCC = builder.get_object('entryBCC')
 	entrySubject = builder.get_object('entrySubject')
 
+	grid1 = builder.get_object('grid1')
+	grid1.set_focus_chain([
+		entryTo,
+		entryCC,
+		entryBCC,
+		entrySubject,
+	])
+
 	textBody = builder.get_object('textviewBody')
 	textBodyBuffer = textBody.get_buffer()
 


### PR DESCRIPTION
This turned out to be a relatively simple fix:

>     def set_focus_chain(focusable_widgets)
>
> "The set_focus_chain() method sets a focus chain, overriding the one computed automatically by GTK."
>
> [— source](https://developer.gnome.org/pygtk/stable/class-gtkcontainer.html#method-gtkcontainer--set-focus-chain)